### PR TITLE
feat: Build and Push Docker Images to Nexus

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Build and Push Docker Images to Nexus
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Log in to Nexus Docker registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
+          registry: ${{ secrets.NEXUS_DOMAIN }}
+
+      - name: Build Frontend Docker image
+        run: |
+          docker build --build-arg REACT_APP_API_URL=${{ secrets.REACT_APP_API_URL }} -t ${{ secrets.NEXUS_DOMAIN }}/${{ secrets.NEXUS_REPOSITORY }}/front_student:${{ github.sha }} ./front_student
+
+      - name: Push Frontend Docker image
+        run: |
+          docker push ${{ secrets.NEXUS_DOMAIN }}/${{ secrets.NEXUS_REPOSITORY }}/front_student:${{ github.sha }}
+
+      - name: Build Backend Docker image
+        run: |
+          docker build -t ${{ secrets.NEXUS_DOMAIN }}/${{ secrets.NEXUS_REPOSITORY }}/back_student:${{ github.sha }} ./back_student
+
+      - name: Push Backend Docker image
+        run: |
+          docker push ${{ secrets.NEXUS_DOMAIN }}/${{ secrets.NEXUS_REPOSITORY }}/back_student:${{ github.sha }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and pushing of Docker images to a Nexus repository. The workflow is triggered on pushes to the `master` branch and includes steps for checking out the code, logging into the Nexus Docker registry, and building and pushing both frontend and backend Docker images.

Key changes:

* Added a new GitHub Actions workflow in `.github/workflows/deploy.yml` to build and push Docker images to Nexus.
* The workflow triggers on pushes to the `master` branch.
* Steps include:
  - Checking out the code using `actions/checkout@v3`.
  - Logging into the Nexus Docker registry using `docker/login-action@v2` with credentials stored in GitHub secrets.
  - Building and pushing the frontend Docker image with a build argument for the API URL.
  - Building and pushing the backend Docker image.